### PR TITLE
added apiToParams

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,5 +66,5 @@
     "watch": "nodemon --watch src --exec \"npm run compile\"",
     "test": "yarn jest --env=jsdom"
   },
-  "version": "0.0.48"
+  "version": "0.0.49"
 }

--- a/src/components/hocs/withSearch.js
+++ b/src/components/hocs/withSearch.js
@@ -10,9 +10,9 @@ import { objectToQueryString } from '../../utils/string'
 
 const withSearch = (config = {}) => WrappedComponent => {
 
-  const { dataKey } = config
+  const { dataKey, queryToApiParams } = config
   const defaultQueryParams = config.defaultQueryParams || {}
-  
+
   class _withSearch extends Component {
     constructor(props) {
       super()
@@ -21,22 +21,25 @@ const withSearch = (config = {}) => WrappedComponent => {
         queryParams: defaultQueryParams,
         value: null
       }
-      props.assignData({ [dataKey]: [] })
-
+      props.dispatch(assignData({ [dataKey]: [] }))
     }
 
     static getDerivedStateFromProps(nextProps, prevState) {
       const queryParams = Object.assign(
-        {},
+        { page: prevState.page },
         defaultQueryParams,
         nextProps.queryParams
       )
+      const querySearch = objectToQueryString(queryParams)
 
-      const querySearch = objectToQueryString(
-        Object.assign({}, queryParams, { page: prevState.page })
-      )
+      const apiParams = queryToApiParams
+        ? queryToApiParams(queryParams)
+        : Object.assign({}, queryParams)
+      const apiSearch = objectToQueryString(apiParams)
 
       return {
+        apiParams,
+        apiSearch,
         queryParams,
         querySearch,
         page: prevState.page,
@@ -75,7 +78,7 @@ const withSearch = (config = {}) => WrappedComponent => {
 
     handleQueryParamsChange = (newValue, config={}) => {
       const {
-        assignData,
+        dispatch,
         history,
         location
       } = this.props
@@ -92,7 +95,7 @@ const withSearch = (config = {}) => WrappedComponent => {
       const newPath = `${pathname}?${queryString}`
 
       if (isRefreshing) {
-        assignData({ [dataKey]: [] })
+        dispatch(assignData({ [dataKey]: [] }))
       }
 
       this.setState({
@@ -161,8 +164,7 @@ const withSearch = (config = {}) => WrappedComponent => {
     connect(
       (state, ownProps) => ({
         queryParams: searchSelector(state, ownProps.location.search)
-      }),
-      { assignData }
+      })
     )
   )(_withSearch)
 }

--- a/src/components/hocs/withSearch.js
+++ b/src/components/hocs/withSearch.js
@@ -112,7 +112,9 @@ const withSearch = (config = {}) => WrappedComponent => {
       let nextValue = value
       const previousValue = queryParams[key]
       if (get(previousValue, 'length')) {
-        nextValue = `${previousValue},${value}`
+        const args = previousValue.split(',').concat([value])
+        args.sort()
+        nextValue = args.join(',')
       } else if (typeof previousValue === "undefined") {
        console.warn(`Weird did you forget to mention this ${key} query param in your withSearch hoc ?`)
       }
@@ -127,7 +129,7 @@ const withSearch = (config = {}) => WrappedComponent => {
       const previousValue = queryParams[key]
       if (get(previousValue, 'length')) {
         let nextValue = previousValue.replace(`,${value}`, '')
-                                       .replace(value, '')
+                                     .replace(value, '')
         if (nextValue[0] === ',') {
           nextValue = nextValue.slice(1)
         }

--- a/src/utils/string.js
+++ b/src/utils/string.js
@@ -65,6 +65,24 @@ export function updateQueryString(string, object) {
   return objectToQueryString(nextObject)
 }
 
+const mapQueryToApi = {
+  lieu: 'venueId',
+  structure: 'offererId',
+}
+
+export function getObjectWithMappedKeys(obj, keysMap) {
+  const mappedObj = {}
+  Object.keys(keysMap)
+        .forEach(objKey => {
+          let mappedKey = objKey
+          if (mapQueryToApi[objKey]) {
+            mappedKey = keysMap[objKey]
+          }
+          mappedObj[mappedKey] = obj[objKey]
+        })
+  return mappedObj
+}
+
 export function formatSiren(string) {
   const value = removeWhitespaces(string)
   if (!value) {

--- a/src/utils/string.js
+++ b/src/utils/string.js
@@ -65,17 +65,12 @@ export function updateQueryString(string, object) {
   return objectToQueryString(nextObject)
 }
 
-const mapQueryToApi = {
-  lieu: 'venueId',
-  structure: 'offererId',
-}
-
 export function getObjectWithMappedKeys(obj, keysMap) {
   const mappedObj = {}
   Object.keys(keysMap)
         .forEach(objKey => {
           let mappedKey = objKey
-          if (mapQueryToApi[objKey]) {
+          if (keysMap[objKey]) {
             mappedKey = keysMap[objKey]
           }
           mappedObj[mappedKey] = obj[objKey]


### PR DESCRIPTION
Une augmentation de withSearch qui permet d'avoir maintenant un apiSearch, et un apiParams.

Qui sont en fait les querySearch et queryParams (normalement en francais pour nous), transformés en ce qu'on veut (normalement en des mots en anglais pour notre api) en specifiant une queryToApiParams function dans la config de withSearch.

Voir un exemple avec cette PR: https://github.com/betagouv/pass-culture-pro/pull/147
