### PR TITLE
Allow the null value for DateInput

### DIFF
--- a/src/components/forms/DateInput.js
+++ b/src/components/forms/DateInput.js
@@ -7,7 +7,7 @@ import Icon from '../Icon'
 class DateInput extends Component {
   onChange = date => {
     const { onChange: fieldOnChange } = this.props
-    const value = date.toISOString()
+    const value = date ? date.toISOString() : { [this.props.name]: null }
     fieldOnChange(value, { event: { target: { value } } })
   }
 


### PR DESCRIPTION
This is needed in order to send  value to the API, to reset a field value