### PR TITLE
made withLogin like a hoc route preventing or not to render children …

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,5 +68,5 @@
     "watch": "nodemon --watch src --exec \"npm run compile\"",
     "test": "yarn jest --env=jsdom"
   },
-  "version": "0.0.77"
+  "version": "0.0.78"
 }

--- a/src/components/hocs/withLogin.js
+++ b/src/components/hocs/withLogin.js
@@ -1,3 +1,4 @@
+import PropTypes from 'prop-types'
 import React, { PureComponent } from 'react'
 import { connect } from 'react-redux'
 import { withRouter } from 'react-router-dom'
@@ -6,31 +7,85 @@ import { compose } from 'redux'
 import { requestData } from '../../reducers/data'
 
 const withLogin = (config = {}) => WrappedComponent => {
-  const { failRedirect, successRedirect } = config
+  const { failRedirect, isRequired, successRedirect } = config
 
   class _withLogin extends PureComponent {
+    constructor () {
+      super()
+      this.state = { canRenderChildren: false }
+    }
 
     componentDidMount = prevProps => {
-      const { dispatch, history, location, user } = this.props
+      const {
+        dispatch,
+        history,
+        location,
+        user
+      } = this.props
+      const { canRenderChildren } = this.state
 
-      if (user !== null) return
+      // we are logged already so cool
+      // we can render children
+      if (user !== null && !canRenderChildren) {
+        this.setState({ canRenderChildren: true })
+      }
 
       dispatch(requestData('GET', `users/current`, {
-        handleSuccess: () => {
-          if (successRedirect && successRedirect !== location.pathname)
-            history.push(successRedirect)
-        },
         handleFail: () => {
-          if (failRedirect && failRedirect !== location.pathname)
-            history.push(failRedirect)
+          if (failRedirect) {
+            let computedFailRedirect = failRedirect
+            if (typeof failRedirect === 'function') {
+              computedFailRedirect = successRedirect(this.props)
+            }
+            if (computedFailRedirect === location.pathname) {
+              return
+            }
+            history.push(computedFailRedirect)
+          }
+
+          // if the login failed and that the login
+          // is not required we can still render what
+          // is in the page
+          if (!isRequired) {
+            this.setState({ canRenderChildren: true })
+          }
         },
+        handleSuccess: () => {
+          if (successRedirect) {
+            let computedSuccessRedirect = successRedirect
+            if (typeof successRedirect === 'function') {
+              computedSuccessRedirect = successRedirect(this.props)
+            }
+            if (computedSuccessRedirect === location.pathname) {
+              return
+            }
+            history.push(computedSuccessRedirect)
+            return
+          }
+          this.setState({ canRenderChildren: true })
+        }
       }))
     }
 
     render() {
+      const { canRenderChildren } = this.state
+      if (!canRenderChildren) {
+        return null
+      }
       return <WrappedComponent {...this.props} />
     }
   }
+
+  _withLogin.defaultProps = {
+    user: null
+  }
+
+  _withLogin.propTypes = {
+    history: PropTypes.object.isRequired,
+    location: PropTypes.object.isRequired,
+    user: PropTypes.oneOfType([PropTypes.object, PropTypes.bool])
+  }
+
   return compose(
     withRouter,
     connect(state => ({ user: state.user }))


### PR DESCRIPTION
…route when login isRequired

Voilà mon avis pour les histoires de syntaxe pour handle le login au niveau des Routes de react-router.

On pourrait réeecrire les fichiers Root.js avec ce genre de practice:
https://medium.com/the-many/adding-login-and-authentication-sections-to-your-react-or-react-native-app-7767fd251bd1
```
<Route component={EnsureLoggedInContainer}>
  ...<Route render={<LoggedPage />}
</Route>
```
Mais je crois que ça demanderait: 
- qu'on resepare le fichier routes en deux, avec un autres loggedRoutes notamment, 
- qu'on rajoute un reducer redirectUrl, 
- qu'on garde un withLogin-componentDidMount au niveau de l'App elle meme qui watch quand même  le chgmt de user et qui fait la requestData.

Donc la solution ici https://stackoverflow.com/questions/32898264/react-router-authorization pour react-router 4, me semble élégante. 
C'est à dire que j'aime bien garder à l'echelle de chaque page le choix granulaire si :
- elle ne se render que quand forcement il doit y avoir un loggedUser (typiquement le cas des pages avec des gestions de données VenuePage, OfferePage...)
- elle peuvent se render quand le retour du requestData get user fail mais que le l'attribute isRequired de withLogin est quand même setté à false. (typiquement le cas d'une HomePage qui doit rendre pour la première connection d'un utilisateur, mais qui doit redirect quand le user est déjà loggé avec un cookie)
Et que ceci soit contenu dans un seul hoc, qui fait toute la logique à un seul endroit, configuré specifiquement pour chaque page.

Donc après, ce hoc pourrait en fait etre un container directement des components de Route, et non pas un hoc sur les components Page, ca c'est vrai. 
Mais vous pourriez me dire alors l'interet, car en fait il ne s'agit que de choisir entre 
une logique de compose:
- tel que nous l'avons aujourd'hui, on est en compose(Route, withLogin, Page)
- et on pourrait demander de faire plutôt compose(withLogin, Route, Page), mais je ne sais pas pour quel prix. Et tel que nos components Root sont écrits, ca demanderait de la réécriture pour exprimer cela, notamment une expression un peu plsu complexe de nos arrays utils de routes dans routes.js, qui devrait notamment avoir un champ en plus comme 
```
{
    component: VenuePage,
    path: '/lieu',
    withLogin: withLogin({ failRedirect: '/connexion', isRequired: true })
},
{
  component: HomePage,
    path: '/home',
    withLogin: withLogin({ successRedirect: '/offres' }),
}
```
et que donc dans Root on fasse des trucs du genre
```
{routes && routes.map(obj => obj && (obj.withLogin 
   ? <withLogin> <Route {...obj} key={obj.path} /> </withLogin> 
   :  <Route {...obj} key={obj.path} />
 )}
```

(et que donc withLogin n est plus un hoc dans ce cas, mais un Container de children.
Ben en fait, juste qu'en prensez-vous, un withLogin plutôt HOC de type Route-withLogin-Page
OU un withLogin plutot container de type withLogin-Route-Page ?

Là dans cette PR le withLogin est format HOC, mais à tres peu cher il peut se transformer en container.
(mais alors il faut reecrire les fichiers routes.js et Root.js dans les deux applis)