### PR TITLE
PC 453 added mergeData action

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,5 +75,5 @@
     "watch": "nodemon --watch src --exec \"npm run compile\"",
     "test:unit": "yarn jest --env=jsdom ./src"
   },
-  "version": "0.0.91"
+  "version": "0.0.92"
 }

--- a/src/reducers/data.js
+++ b/src/reducers/data.js
@@ -1,6 +1,7 @@
 import { getNextState } from '../utils/data'
 
 export const ASSIGN_DATA = 'ASSIGN_DATA'
+export const MERGE_DATA = 'MERGE_DATA'
 export const RESET_DATA = 'RESET_DATA'
 
 export const createData = (initialState = {}) => (
@@ -9,6 +10,10 @@ export const createData = (initialState = {}) => (
 ) => {
   if (action.type === ASSIGN_DATA) {
     return Object.assign({}, state, action.patch)
+  }
+  if (action.type ===  MERGE_DATA) {
+    const nextState = getNextState(state, 'GET', action.patch, action.config)
+    return Object.assign({}, state, nextState)
   }
   if (action.type === RESET_DATA) {
     return initialState
@@ -48,6 +53,12 @@ export const createData = (initialState = {}) => (
 export const assignData = patch => ({
   patch,
   type: ASSIGN_DATA,
+})
+
+export const mergeData = (patch, config) => ({
+  config,
+  patch,
+  type: MERGE_DATA
 })
 
 export const failData = (method, path, errors, config) => ({


### PR DESCRIPTION
Voir https://github.com/betagouv/pass-culture-browser/pull/1017/files

pour stocker dans le redux-persist-local storage des:

```
readRecommendations: [{ id: 'AH', dateRead: 'DD-MM-YY' }, { id: 'ERAS', dateRead: 'DD-MM-YY2' }]
```

j'utilise l'action (https://github.com/betagouv/pass-culture-browser/pull/1017/files#diff-d8711afcabe61d421e7d75c7bc369c1aR98)

```
mergeData({ readRecommendations: [readRecommendation] })
```

comme ca s'accumule dans l'array  readRecommendations du state.data.readRecommendations et le redux persist fait le sync avec mon local storage (ou mon potentiel async storage si un jour on passe en react native)

