### PR TITLE
[PC 1423] Unmount option modal

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,5 +75,5 @@
     "watch": "nodemon --watch src --exec \"npm run compile\"",
     "test:unit": "yarn jest --env=jsdom ./src"
   },
-  "version": "0.0.100"
+  "version": "0.0.101"
 }

--- a/src/reducers/modal.js
+++ b/src/reducers/modal.js
@@ -12,6 +12,7 @@ export function modal(state = initialState, action) {
   switch (action.type) {
     case CLOSE_MODAL:
       return Object.assign({}, state, {
+        $modal: action.keepComponentMounted ? state.$modal : null,
         isActive: false,
       })
     case ASSIGN_MODAL_CONFIG:
@@ -33,8 +34,8 @@ export function assignModalConfig(config) {
   return { config, type: ASSIGN_MODAL_CONFIG }
 }
 
-export function closeModal() {
-  return { type: CLOSE_MODAL }
+export function closeModal(keepComponentMounted) {
+  return { keepComponentMounted, type: CLOSE_MODAL }
 }
 
 export function showModal($modal, config) {


### PR DESCRIPTION
C'est plus évident de faire que le closeModal unmount le component rendu.
Comme ca pas de risque de side effect avec l'element $modal qui pourrait instancer des event listeners par exemples sur le document sur des pages où l'on ne le souhaite pas.