### PR TITLE
(PC-1647) parse form child

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,5 +78,5 @@
     "watch": "nodemon --watch src --exec \"npm run compile\"",
     "test:unit": "yarn jest --env=jsdom ./src"
   },
-  "version": "0.1.0-alpha12"
+  "version": "0.1.0-alpha15"
 }


### PR DESCRIPTION
C'est un workaround ici, tant qu'on aura pas tout remplacé les Form de shared par ceux de react-final-form.

Cette PR permet de forcer ce cas:
```
render () {
  return (
   <Form>
     <MyReactComponent />
  </Form>
 )
}
```
dans lequel `MyReactComponent`possede des 'Fields' components qui sont bien parsés pendant le recursiveMap.






LE PREMIER COMMIT EST UN CHERRY PICK 5e11313
à enlever des que pc-1629 est mergée sur shared

et pc-1629 est elle meme en attente de webapp pc-1622 pour etre mergée.